### PR TITLE
Adds ModMenu `library` badge.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,5 +27,10 @@
     "fabric": ">=0.47.8+1.18.2",
     "minecraft": ">=1.18.1",
     "java": ">=17"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   }
 }


### PR DESCRIPTION
This allows to filter library mods in [ModMenu](https://github.com/TerraformersMC/ModMenu/wiki/API#badges).